### PR TITLE
Pyarrow dep should be pinned

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or linux32 or py2k]
 
 requirements:
@@ -65,7 +65,7 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow >=0.16.*
+        - pyarrow 1.0.*
         - pybind11
         - rpdb
         - wheel
@@ -76,7 +76,7 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow >=0.16.*
+        - pyarrow 1.0.*
         - pybind11
         - setuptools
     imports:


### PR DESCRIPTION
We link against the specific library so if a version changes right now we break.