### PR TITLE
Update TileDB-VCF to 0.11.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ conda search libtiledbvcf --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/build-locally.py
+++ b/build-locally.py
@@ -22,6 +22,10 @@ def setup_environment(ns):
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
         )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
+        )
 
 
 def run_docker_build(ns):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vcf" %}
-{% set version = "0.11.1" %}
-{% set sha256 = "cf8ad7a79e6309b535089c6994af9ec22c38a9c45712640049ad789e96d53f70" %}
+{% set version = "0.11.2" %}
+{% set sha256 = "b3351edb2f5f675f22335bb4b2be40ffb8d99bb5176a97268919583feff061e2" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vcf" %}
-{% set version = "0.11.2.1" %}
-{% set sha256 = "8b4ecdf73e39da46e6c94f5219db1181979d7b762517a145cdab75c0a2608652" %}
+{% set version = "0.11.3" %}
+{% set sha256 = "e8edc8a0b516de5bc94feab53a17372f357ee620958eb3d28e51eb47f4557fb6" %}
 
 package:
   name: {{ name }}
@@ -11,7 +11,7 @@ source:
   #git_rev: {{ version }}
   #fn: {{ name }}-{{ version }}.tar.gz
   #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  url: https://github.com/TileDB-Inc/TileDB-VCF/archive/master.tar.gz
+  url: https://github.com/TileDB-Inc/TileDB-VCF/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vcf" %}
-{% set version = "0.11.2" %}
-{% set sha256 = "b3351edb2f5f675f22335bb4b2be40ffb8d99bb5176a97268919583feff061e2" %}
+{% set version = "0.11.2.1" %}
+{% set sha256 = "8b4ecdf73e39da46e6c94f5219db1181979d7b762517a145cdab75c0a2608652" %}
 
 package:
   name: {{ name }}
@@ -11,7 +11,7 @@ source:
   #git_rev: {{ version }}
   #fn: {{ name }}-{{ version }}.tar.gz
   #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  url: https://github.com/TileDB-Inc/TileDB-VCF/archive/{{ version }}.tar.gz
+  url: https://github.com/TileDB-Inc/TileDB-VCF/archive/master.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
The 0.11.2 update revealed a build issue on macOS Catalina. This was subsequently patched in tiledb-inc/tiledb-vcf#392 and rolled into 0.11.3. 