### PR TITLE
Update pyarrow pin to 10.0.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vcf" %}
 {% set version = "0.20.2" %}
-{% set sha256 = "e460d115d165f13b2b1d382264b081f0c77656bb6650635e4576df97ee5601b5" %}
+{% set sha256 = "217652ad87b0ef448460597d589342d5850c653afabc5fa939cd32b787a5e9ba" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 
 requirements:
@@ -65,7 +65,8 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow 6.0.*
+        - pyarrow 10.0.* # [py>37]
+        - pyarrow 9.0.* # [py<38]
         - pybind11
         - rpdb
         - wheel
@@ -76,7 +77,8 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow 6.0.*
+        - pyarrow 10.0.* # [py>37]
+        - pyarrow 9.0.* # [py<38]
         - pybind11
         - setuptools
         - pandas


### PR DESCRIPTION
Update pyarrow pin to 10.0.*

This also sets pyarrow to 9.0 for python 3.7. `pyarrow` 9 was the last build against python 3.7 in conda-forge.