### PR TITLE
Customize feedstock for TileDB-Inc

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - name: automerge-action
         id: automerge-action
-        uses: conda-forge/automerge-action@master
+        uses: conda-forge/automerge-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: webservices
         id: webservices
-        uses: conda-forge/webservices-dispatch-action@master
+        uses: conda-forge/webservices-dispatch-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://tiledb.com
 
 Package license: MIT
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tiledb-vcf-feedstock/blob/master/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledb-vcf-feedstock/blob/master/LICENSE.txt)
 
 Summary: Efficient variant-call data storage and retrieval library using the TileDB storage library.
 
@@ -27,8 +27,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=master">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master">
+          <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+            <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master">
           </a>
         </summary>
         <table>
@@ -36,15 +36,15 @@ Current build status
           <tbody><tr>
               <td>linux_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr>
@@ -60,20 +60,20 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-libtiledbvcf-green.svg)](https://anaconda.org/conda-forge/libtiledbvcf) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libtiledbvcf.svg)](https://anaconda.org/conda-forge/libtiledbvcf) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libtiledbvcf.svg)](https://anaconda.org/conda-forge/libtiledbvcf) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libtiledbvcf.svg)](https://anaconda.org/conda-forge/libtiledbvcf) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-tiledbvcf--py-green.svg)](https://anaconda.org/conda-forge/tiledbvcf-py) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tiledbvcf-py.svg)](https://anaconda.org/conda-forge/tiledbvcf-py) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tiledbvcf-py.svg)](https://anaconda.org/conda-forge/tiledbvcf-py) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tiledbvcf-py.svg)](https://anaconda.org/conda-forge/tiledbvcf-py) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libtiledbvcf-green.svg)](https://anaconda.org/tiledb/libtiledbvcf) | [![Conda Downloads](https://img.shields.io/conda/dn/tiledb/libtiledbvcf.svg)](https://anaconda.org/tiledb/libtiledbvcf) | [![Conda Version](https://img.shields.io/conda/vn/tiledb/libtiledbvcf.svg)](https://anaconda.org/tiledb/libtiledbvcf) | [![Conda Platforms](https://img.shields.io/conda/pn/tiledb/libtiledbvcf.svg)](https://anaconda.org/tiledb/libtiledbvcf) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-tiledbvcf--py-green.svg)](https://anaconda.org/tiledb/tiledbvcf-py) | [![Conda Downloads](https://img.shields.io/conda/dn/tiledb/tiledbvcf-py.svg)](https://anaconda.org/tiledb/tiledbvcf-py) | [![Conda Version](https://img.shields.io/conda/vn/tiledb/tiledbvcf-py.svg)](https://anaconda.org/tiledb/tiledbvcf-py) | [![Conda Platforms](https://img.shields.io/conda/pn/tiledb/tiledbvcf-py.svg)](https://anaconda.org/tiledb/tiledbvcf-py) |
 
 Installing tiledb-vcf
 =====================
 
-Installing `tiledb-vcf` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `tiledb-vcf` from the `tiledb` channel can be achieved by adding `tiledb` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels tiledb
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libtiledbvcf, tiledbvcf-py` can be installed with `conda`:
+Once the `tiledb` channel has been enabled, `libtiledbvcf, tiledbvcf-py` can be installed with `conda`:
 
 ```
 conda install libtiledbvcf tiledbvcf-py
@@ -88,68 +88,29 @@ mamba install libtiledbvcf tiledbvcf-py
 It is possible to list all of the versions of `libtiledbvcf` available on your platform with `conda`:
 
 ```
-conda search libtiledbvcf --channel conda-forge
+conda search libtiledbvcf --channel tiledb
 ```
 
 or with `mamba`:
 
 ```
-mamba search libtiledbvcf --channel conda-forge
+mamba search libtiledbvcf --channel tiledb
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search libtiledbvcf --channel conda-forge
+mamba repoquery search libtiledbvcf --channel tiledb
 
 # List packages depending on `libtiledbvcf`:
-mamba repoquery whoneeds libtiledbvcf --channel conda-forge
+mamba repoquery whoneeds libtiledbvcf --channel tiledb
 
 # List dependencies of `libtiledbvcf`:
-mamba repoquery depends libtiledbvcf --channel conda-forge
+mamba repoquery depends libtiledbvcf --channel tiledb
 ```
 
 
-About conda-forge
-=================
-
-[![Powered by
-NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
-
-conda-forge is a community-led conda channel of installable packages.
-In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository
-for each of the installable packages. Such a repository is known as a *feedstock*.
-
-A feedstock is made up of a conda recipe (the instructions on what and how to build
-the package) and the necessary configurations for automatic building using freely
-available continuous integration services. Thanks to the awesome service provided by
-[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
-[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
-it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
-channel for Linux, Windows and OSX respectively.
-
-To manage the continuous integration and simplify feedstock maintenance
-[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
-Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
-this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
-
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
-
-Terminology
-===========
-
-**feedstock** - the conda recipe (raw material), supporting scripts and CI configuration.
-
-**conda-smithy** - the tool which helps orchestrate the feedstock.
-                   Its primary use is in the construction of the CI ``.yml`` files
-                   and simplify the management of *many* feedstocks.
-
-**conda-forge** - the place where the feedstock and smithy live and work to
-                  produce the finished article (built conda distributions)
 
 
 Updating tiledb-vcf-feedstock
@@ -160,9 +121,9 @@ package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
-`conda-forge` channel, whereupon the built conda packages will be available for
-everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/tiledb-vcf-feedstock are
+`tiledb` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `tiledb` channel.
+Note that all branches in the TileDB-Inc/tiledb-vcf-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,10 @@
-{}
+channels:
+  sources:
+    - conda-forge
+    - bioconda
+  targets:
+    - ["tiledb", "main"]
+github:
+  user_or_org: TileDB-Inc
+  branch_name: master
+  tooling_branch_name: main

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 channels:
   sources:
     - conda-forge
-    - bioconda
   targets:
     - ["tiledb", "main"]
 github:


### PR DESCRIPTION
This is a quality of life PR. I noticed the badges and instructions in the README were all for the conda-forge org and channel. Now they apply to TileDB-Inc GitHub org and the tiledb channel.

Specifically, I did the following:

* `user_or_org: TileDB-Inc` updates some URLs in the README
* `tooling_branch_name: main` this ensures that future conda-smithy rerenders don't undo the changes from PR #58
* `channels` updates the badge links to anaconda.org as well as the README installation instructions (note that the channels set in `recipe/conda_build_config.yaml` affect the build process, but not the feedstock rerendering)