### PR TITLE
Upgrade pyarrow to 9.0.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vcf" %}
 {% set version = "0.20.2" %}
-{% set sha256 = "e460d115d165f13b2b1d382264b081f0c77656bb6650635e4576df97ee5601b5" %}
+{% set sha256 = "217652ad87b0ef448460597d589342d5850c653afabc5fa939cd32b787a5e9ba" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow 6.0.*
+        - pyarrow 9.0.*
         - pybind11
         - rpdb
         - wheel
@@ -76,7 +76,7 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow 6.0.*
+        - pyarrow 9.0.*
         - pybind11
         - setuptools
         - pandas


### PR DESCRIPTION
Pyarrow 9 is the last verison with pytohn 3.7 support. There is also some build conflict with pyarrow 10.0 and htslib, thus we'll stick with pyarrow 9 for now.