### PR TITLE
Add libdeflate build permutations

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_libdeflate1.12:
+        CONFIG: linux_64_libdeflate1.12
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_libdeflate1.13:
+        CONFIG: linux_64_libdeflate1.13
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_libdeflate1.14:
+        CONFIG: linux_64_libdeflate1.14
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,14 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_libdeflate1.12:
+        CONFIG: osx_64_libdeflate1.12
+        UPLOAD_PACKAGES: 'True'
+      osx_64_libdeflate1.13:
+        CONFIG: osx_64_libdeflate1.13
+        UPLOAD_PACKAGES: 'True'
+      osx_64_libdeflate1.14:
+        CONFIG: osx_64_libdeflate1.14
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_libdeflate1.12.yaml
+++ b/.ci_support/linux_64_libdeflate1.12.yaml
@@ -1,0 +1,38 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '11'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- tiledb main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libdeflate:
+- '1.12'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libdeflate1.13.yaml
+++ b/.ci_support/linux_64_libdeflate1.13.yaml
@@ -16,12 +16,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-libcurl:
-- '7'
 libdeflate:
-- '1.14'
-openssl:
-- 1.1.1
+- '1.13'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_libdeflate1.14.yaml
+++ b/.ci_support/linux_64_libdeflate1.14.yaml
@@ -1,0 +1,38 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '11'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- tiledb main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libdeflate:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_libdeflate1.12.yaml
+++ b/.ci_support/osx_64_libdeflate1.12.yaml
@@ -1,0 +1,40 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '14'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- tiledb main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '14'
+libdeflate:
+- '1.12'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_libdeflate1.13.yaml
+++ b/.ci_support/osx_64_libdeflate1.13.yaml
@@ -1,0 +1,40 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '14'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- tiledb main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '14'
+libdeflate:
+- '1.13'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_libdeflate1.14.yaml
+++ b/.ci_support/osx_64_libdeflate1.14.yaml
@@ -16,14 +16,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
-libcurl:
-- '7'
 libdeflate:
 - '1.14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-openssl:
-- 1.1.1
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/README.md
+++ b/README.md
@@ -34,17 +34,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_libdeflate1.12</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_libdeflate1.12" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_64_libdeflate1.13</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_libdeflate1.13" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_libdeflate1.14</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_libdeflate1.14" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libdeflate1.12</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_libdeflate1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libdeflate1.13</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_libdeflate1.13" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libdeflate1.14</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_libdeflate1.14" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -21,3 +21,7 @@ python_impl:
   - cpython
   - cpython
   - cpython
+libdeflate:
+  - 1.12
+  - 1.13
+  - 1.14

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0001-htslib-build.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win or linux32 or py2k]
 
 requirements:


### PR DESCRIPTION
Add libdeflate build permutations. This is needed because many bioconda packages were last build with libdeflate 1.13. We add support for 1.12 and 1.14 to make the dependency resolving more robust for users.