### PR TITLE
Repair numpy pins

### DIFF
--- a/.ci_support/linux_64_libdeflate1.12.yaml
+++ b/.ci_support/linux_64_libdeflate1.12.yaml
@@ -18,6 +18,11 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libdeflate:
 - '1.12'
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -34,5 +39,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libdeflate1.13.yaml
+++ b/.ci_support/linux_64_libdeflate1.13.yaml
@@ -18,6 +18,11 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libdeflate:
 - '1.13'
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -34,5 +39,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libdeflate1.14.yaml
+++ b/.ci_support/linux_64_libdeflate1.14.yaml
@@ -18,6 +18,11 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libdeflate:
 - '1.14'
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -34,5 +39,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libdeflate1.16.yaml
+++ b/.ci_support/linux_64_libdeflate1.16.yaml
@@ -18,6 +18,11 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libdeflate:
 - '1.16'
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -34,5 +39,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libdeflate1.17.yaml
+++ b/.ci_support/linux_64_libdeflate1.17.yaml
@@ -18,6 +18,11 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libdeflate:
 - '1.17'
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -34,5 +39,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_libdeflate1.12.yaml
+++ b/.ci_support/osx_64_libdeflate1.12.yaml
@@ -20,6 +20,11 @@ libdeflate:
 - '1.12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +41,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_libdeflate1.13.yaml
+++ b/.ci_support/osx_64_libdeflate1.13.yaml
@@ -20,6 +20,11 @@ libdeflate:
 - '1.13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +41,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_libdeflate1.14.yaml
+++ b/.ci_support/osx_64_libdeflate1.14.yaml
@@ -20,6 +20,11 @@ libdeflate:
 - '1.14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +41,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_libdeflate1.16.yaml
+++ b/.ci_support/osx_64_libdeflate1.16.yaml
@@ -20,6 +20,11 @@ libdeflate:
 - '1.16'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +41,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_libdeflate1.17.yaml
+++ b/.ci_support/osx_64_libdeflate1.17.yaml
@@ -20,6 +20,11 @@ libdeflate:
 - '1.17'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +41,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy
 zlib:
 - '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0001-htslib-build.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 
 requirements:
@@ -73,8 +73,8 @@ outputs:
         - cmake
         - make
       host:
-        - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
-        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
+        - numpy
+        - libtiledbvcf {{ version }}
         - python
         - pyarrow 9.0.*
         - pybind11


### PR DESCRIPTION
**tl;dr** The numpy pinnings in `recipe/conda_build_config.yaml` were ignored because they were not propogated to the yaml files in `.ci_support/`. The cause was the use of `pin_compatible('numpy')` in the host dependencies

**question:** How important is it to support Python 3.7? conda-forge has officially [dropped support for Python 3.7](https://conda-forge.org/docs/user/announcements.html#dropping-python-3-7), and we could simplify the maintenance of this feedstock by also dropping it (so that we can simply rely on the upstream conda-forge pinnings)

I've long been confused by the updates to `recipe/conda_build_config.yaml` in a5c01af09e591a05cdab5712f1fea2e4ad164d6d since they seem unrelated to building htslib. I think I understand them now. In order to continue building for Python 3.7, we need to explicitly include it (plus all the other versions, since edits in `recipe/conda_build_config.yaml` are not additive, but completely replace the conda-forge pinnings). However, as I try to update the recipe for a Windows build, I keep getting numpy solver errors. And when I look at the currently successful Azure builds, the version of numpy installed is not consistent with the values in `recipe/conda_build_config.yaml`. I eventually figured out that this is because the `numpy` field is not progated to the yaml files in `.ci_support/`, and thus are completely ignored.

I figured out the solution by looking at the [arrow-cpp recipe](https://github.com/conda-forge/arrow-cpp-feedstock/blob/32a27bf36e839abf426c6ba1139d674accae51a7/recipe/meta.yaml). It only uses `pin_compatible('numpy')` in the run dependencies. Looking at the [conda docs](https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#extra-jinja2-functions), it is only supposed to be used here:

> `pin_compatible('package_name', min_pin='x.x.x.x.x.x', max_pin='x', lower_bound=None, upper_bound=None)`: To be used as pin in run and/or test requirements.

This is also consistent with the [conda-forge advice for pinning numpy](https://conda-forge.org/docs/maintainer/knowledge_base.html#linking-numpy).

When I removed `pin_compatible()`, then `conda smithy rerender` adds numpy to the yaml files in `.ci_support/`. And during the builds, the exact pinned numpy versions are installed. However, in the tests, a more recent version of numpy is installed, which is consistent with the current bounds in the recipe:

https://github.com/TileDB-Inc/tiledb-vcf-feedstock/blob/63319b071061cdfc8ab3ae067f3291e31af4aed1/recipe/meta.yaml#L86-L87

While I was making this change, I also removed `pin_subpackage('libtiledbvcf', exact=True)` from the host dependencies since the conda docs also say this function is only supposed to be used in the run dependencies. This isn't as important as a change. I tested on my fork that it works without it, and to be extra cautious, I also pinned `{{ version }}`. Essentially, I'm trying to follow the official conda docs to avoid future problems. Note that arrow-cpp does use `pin_subpackage()` in their host deps, and I suspect that could be removed as well.