### PR TITLE
Fix libdeflate linking for vendored htslib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ihnorton @shelnutt2
+* @ihnorton @jdblischak @shelnutt2

--- a/README.md
+++ b/README.md
@@ -195,5 +195,6 @@ Feedstock Maintainers
 =====================
 
 * [@ihnorton](https://github.com/ihnorton/)
+* [@jdblischak](https://github.com/jdblischak/)
 * [@shelnutt2](https://github.com/shelnutt2/)
 

--- a/recipe/0001-htslib-build.patch
+++ b/recipe/0001-htslib-build.patch
@@ -7,7 +7,7 @@ index 3e5b4e7..3688982 100644
            ${AUTORECONF} -i
          COMMAND
 -          ./configure --prefix=${EP_INSTALL_PREFIX} LDFLAGS=${EXTRA_LDFLAGS} CFLAGS=${CFLAGS}
-+          ./configure --disable-libcurl --disable-gcs --disable-aws --prefix=${EP_INSTALL_PREFIX} LDFLAGS=${EXTRA_LDFLAGS} CFLAGS=${CFLAGS}
++          ./configure --with-libdeflate --disable-libcurl --disable-gcs --disable-aws --prefix=${EP_INSTALL_PREFIX} LDFLAGS=${EXTRA_LDFLAGS} CFLAGS=${CFLAGS}
        BUILD_COMMAND
          $(MAKE)
        INSTALL_COMMAND

--- a/recipe/build-libtiledbvcf.sh
+++ b/recipe/build-libtiledbvcf.sh
@@ -3,6 +3,7 @@
 set -exo pipefail
 
 mkdir libtiledbvcf-build && cd libtiledbvcf-build
+
 cmake \
   -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
   -DOVERRIDE_INSTALL_PREFIX=OFF \
@@ -11,3 +12,5 @@ cmake \
   ../libtiledbvcf
 
 make -j ${CPU_COUNT}
+
+make install-libtiledbvcf

--- a/recipe/install-libtiledbvcf.sh
+++ b/recipe/install-libtiledbvcf.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -exo pipefail
-
-cd libtiledbvcf-build
-make install-libtiledbvcf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,6 +80,12 @@ outputs:
     test:
       commands:
         - python -c "import tiledbvcf; tiledbvcf.version"
+        # verify libhts is linked
+        - ldd ${PREFIX}/lib/libtiledbvcf.so | grep libhts  # [linux]
+        - otool -L ${PREFIX}/lib/libtiledbvcf.dylib | grep libhts  # [osx]
+        # verify libdeflate is linked to libhts
+        - ldd ${PREFIX}/lib/libhts.so.* | grep libdeflate  # [linux]
+        - otool -L ${PREFIX}/lib/libhts.*.dylib | grep libdeflate  # [osx]
 
 about:
   home: http://tiledb.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,10 +7,6 @@ package:
   version: {{ version }}
 
 source:
-  #git_url: https://github.com/TileDB-Inc/TileDB-VCF.git
-  #git_rev: {{ version }}
-  #fn: {{ name }}-{{ version }}.tar.gz
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   url: https://github.com/TileDB-Inc/TileDB-VCF/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
@@ -20,27 +16,15 @@ build:
   number: 2
   skip: true  # [win or linux32 or py2k]
 
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - git
-    - cmake
-    - make
-    - autoconf
-    - automake
-  run:
-    - tiledb 2.14.*
-  host:
-    - tiledb 2.14.*
 outputs:
   - name: libtiledbvcf
     version: {{ version }}
-    script: install-libtiledbvcf.sh
+    script: build-libtiledbvcf.sh
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - git
         - cmake
         - make
         - autoconf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0001-htslib-build.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or linux32 or py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,3 +112,4 @@ extra:
   recipe-maintainers:
     - ihnorton
     - shelnutt2
+    - jdblischak


### PR DESCRIPTION
**tl;dr** The vendored htslib isn't linked to libdeflate

**Note:** This PR is intended to initially fail to demonstrate the problem. I already know how to fix it, and will push those commit(s) next

## History of vendored htslib

We recently replaced htslib from bioconda with a vendored htslib build (PR #64; commit a5c01af; version 0.20.2, build 1). Furthermore, since conda-forge only pins a single libdeflate version, we expanded to build for multiple libdeflate versions (PRs #67  and #70)

## Demonstration of libdeflate linking

From the [htslib installation instructions](https://github.com/samtools/htslib/blob/6652c86ab34aed5aaf3e1211ba75cea982ad269c/INSTALL#L175), the default behavior is to search for libdeflate and link to it if it is available. If it can't find it, there is no error. Since cmake suppresses the build logs of external dependencies like htslib, it's not possible to determine from the build logs if the linking occurred or not.

The [bioconda build script](https://github.com/bioconda/bioconda-recipes/blob/6cb443874a8e7c089e76aef7a31eb7eb94416b4f/recipes/htslib/build.sh#L3) explicitly sets `--with-libdeflate`, which causes the htslib build to fail if no libdeflate can be found. I added this to our htslib cmake patch, which then causes the build to fail.

Using `ldd`:

```sh
# htslib from bioconda
mamba create --yes -n test-htslib-bioconda -c bioconda htslib
mamba activate test-htslib-bioconda
ls $CONDA_PREFIX/lib/libhts.*
## $CONDA_PREFIX/lib/libhts.a
## $CONDA_PREFIX/lib/libhts.so
## $CONDA_PREFIX/lib/libhts.so.1.9
## $CONDA_PREFIX/lib/libhts.so.2
ldd $CONDA_PREFIX/lib/libhts.so* | grep libdeflate
##         libdeflate.so => $CONDA_PREFIX/lib/./libdeflate.so (0x00007f3643efa000)
##         libdeflate.so => $CONDA_PREFIX/lib/./libdeflate.so (0x00007f61a4fbc000)
##         libdeflate.so => $CONDA_PREFIX/lib/./libdeflate.so (0x00007fb09c062000)
mamba deactivate

# htslib vendored in libtiledbvcf
mamba create --yes -n test-htslib-tiledbvcf -c conda-forge -c tiledb 'libtiledbvcf=0.22.0=*2'
mamba activate test-htslib-tiledbvcf
mamba list libtiledbvcf
## # Name                    Version                   Build  Channel
## libtiledbvcf              0.22.0               h3156680_2    tiledb
ls $CONDA_PREFIX/lib/*tile*
## $CONDA_PREFIX/lib/libtiledb.so
## $CONDA_PREFIX/lib/libtiledb.so.2.14
## $CONDA_PREFIX/lib/libtiledbvcf.so
ls $CONDA_PREFIX/lib/*hts*
## $CONDA_PREFIX/lib/libhts.so.1.15.1
ldd $CONDA_PREFIX/lib/libtiledbvcf.so | grep libhts
##         libhts.so.1.15.1 => $CONDA_PREFIX/lib/./libhts.so.1.15.1 (0x00007fcb152e2000)
ldd $CONDA_PREFIX/lib/libhts.so.1.15.1 | grep libdeflate
mamba deactivate
```

## Cause

I have always been confused why this recipe includes top-level requirements which are largely redundant to the requirements for the subpackage libtiledbvcf. I previously deleted them, but the builds would always fail. I finally figured it out from this comment https://github.com/conda-forge/conda-forge.github.io/issues/746#issuecomment-937045471 and inspecting the build logs. Essentially, the top-level requirements are installed prior to running the default `build.sh`.

But libdeflate was only added to the requirements in the subpackage section, which simply runs `make install-libtiledbvcf` (in `install-libtiledbvcf.sh`). htslib is built by the call to cmake in `build.sh`, when no libdeflate is available.

## Solution

To both simplify this recipe and fix the linking to libdeflate, I propose combining the code in `build.sh` and `install-libtiledbvcf.sh` into a single file (eg `build-libtiledbvcf.sh`) and removing the top-level requirements section. This will result in libdeflate being available during the htslib build, and it will ease future maintenance (only one requirements section to update), and it will reduce CI time (because running `build.sh` separately requires solving and installing an entirely separate conda env).
