### PR TITLE
Simplify recipe by reducing build steps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ihnorton @shelnutt2
+* @ihnorton @jdblischak @shelnutt2

--- a/README.md
+++ b/README.md
@@ -195,5 +195,6 @@ Feedstock Maintainers
 =====================
 
 * [@ihnorton](https://github.com/ihnorton/)
+* [@jdblischak](https://github.com/jdblischak/)
 * [@shelnutt2](https://github.com/shelnutt2/)
 

--- a/recipe/build-libtiledbvcf.sh
+++ b/recipe/build-libtiledbvcf.sh
@@ -3,6 +3,7 @@
 set -exo pipefail
 
 mkdir libtiledbvcf-build && cd libtiledbvcf-build
+
 cmake \
   -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
   -DOVERRIDE_INSTALL_PREFIX=OFF \
@@ -11,3 +12,5 @@ cmake \
   ../libtiledbvcf
 
 make -j ${CPU_COUNT}
+
+make install-libtiledbvcf

--- a/recipe/install-libtiledbvcf.sh
+++ b/recipe/install-libtiledbvcf.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -exo pipefail
-
-cd libtiledbvcf-build
-make install-libtiledbvcf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,40 +7,24 @@ package:
   version: {{ version }}
 
 source:
-  #git_url: https://github.com/TileDB-Inc/TileDB-VCF.git
-  #git_rev: {{ version }}
-  #fn: {{ name }}-{{ version }}.tar.gz
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   url: https://github.com/TileDB-Inc/TileDB-VCF/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - 0001-htslib-build.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or linux32 or py2k]
 
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - git
-    - cmake
-    - make
-    - autoconf
-    - automake
-  run:
-    - tiledb 2.14.*
-  host:
-    - tiledb 2.14.*
 outputs:
   - name: libtiledbvcf
     version: {{ version }}
-    script: install-libtiledbvcf.sh
+    script: build-libtiledbvcf.sh
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - git
         - cmake
         - make
         - autoconf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,3 +112,4 @@ extra:
   recipe-maintainers:
     - ihnorton
     - shelnutt2
+    - jdblischak


### PR DESCRIPTION
This PR simplifies the recipe by combining the building and installing of libtiledbvcf into a single step. This reduces the requirements to maintain/update (by removing the top-level requirements) and reduces the CI time (by removing one of the conda envs that has to be installed).

Since it was unclear to me how this recipe worked when I first looked at it, here are the steps it currently takes:

1. Install the top-level requirements into conda env 1
2. Execute `build.sh` to build libtiledbvcf
3. Install the requirements for the output libtiledbvcf into conda env 2
4. Execute `install-libtiledbvcf.sh`, which installs libtiledbvcf (`make install-libtiledbvcf`)
5. Install the requirements for the output tiledbvcf-py into conda env 3
6. Execute `build-tiledbvcf-py.sh`, which builds and installs tiledb-vcf

This PR updates the steps to the following:

1. Install the requirements for the output libtiledbvcf into conda env 1
2. Execute `build-libtiledbvcf.sh`, which builds *and* installs libtiledbvcf
3. Install the requirements for the output tiledbvcf-py into conda env 2
4. Execute `build-tiledbvcf-py.sh`, which builds and installs tiledb-vcf
