### PR TITLE
Update tiledbvcf-py dependencies

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About tiledb-vcf
-================
+About tiledb-vcf-feedstock
+==========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledb-vcf-feedstock/blob/master/LICENSE.txt)
 
 Home: http://tiledb.com
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledb-vcf-feedstock/blob/master/LICENSE.txt)
 
 Summary: Efficient variant-call data storage and retrieval library using the TileDB storage library.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win or linux32 or py2k]
 
 outputs:
@@ -50,19 +50,15 @@ outputs:
     script: build-tiledbvcf-py.sh
     requirements:
       build:
-        - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - cmake
-        - make
       host:
         - numpy
         - libtiledbvcf {{ version }}
         - python
         - pyarrow 9.0.*
-        - pybind11
-        - rpdb
-        - wheel
-        - setuptools
+        - pybind11 >=2.5
+        - wheel >=0.30
+        - setuptools >=18.0
         - setuptools_scm 6.0.1
         - setuptools_scm_git_archive
       run:
@@ -70,8 +66,6 @@ outputs:
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
         - pyarrow 9.0.*
-        - pybind11
-        - setuptools
         - pandas
     imports:
       - tiledbvcf


### PR DESCRIPTION
I reduced the dependencies for tiledbvcf-py. The current tests in `test-api.py` still run without issue. Are there any other tests I should add to confirm that the package is 100% functional after removing dependencies?

Here is what I removed and why:

* `{{ compiler('c') }}` - No C code
* `cmake`/`make` - These are only needed for a superbuild. The recipe purposefully builds libtiledbvcf as a conda binary and then provides it to the Python package
* `rpdb` - This is a debugging tool. I couldn't find it anywhere in the source code
* `pybind11` - As of version 2.5, this is not a runtime dependency (https://github.com/pybind/pybind11/pull/1995#issuecomment-606560756; https://github.com/pybind/python_example/pull/47)
* `setuptools` - I removed this from the runtime dependencies. I couldn't find any import in the source code that would require this
* I also added some minimum version requirements based on `setup.py`