### PR TITLE
Build libtiledbvcf for Windows with m2w64-htslib

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,79 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: windows-2022
+  strategy:
+    matrix:
+      win_64_:
+        CONFIG: win_64_
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
+
+  steps:
+    - task: PythonScript@0
+      displayName: 'Download Miniforge'
+      inputs:
+        scriptSource: inline
+        script: |
+          import urllib.request
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
+          urllib.request.urlretrieve(url, path)
+
+    - script: |
+        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
+      displayName: Install Miniforge
+
+    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
+      displayName: Add conda to PATH
+
+    - script: |
+        call activate base
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
+      displayName: Install conda-build
+
+    - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
+
+    # Configure the VM
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+
+    - script: |
+        call activate base
+        if EXIST LICENSE.txt (
+          copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
+        call activate base
+        upload_package  .\ ".\recipe" .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')), not(eq(variables['Build.Reason'], 'PullRequest')))

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,0 +1,10 @@
+c_compiler:
+- vs2019
+channel_sources:
+- conda-forge,tiledb
+channel_targets:
+- tiledb main
+cxx_compiler:
+- vs2019
+target_platform:
+- win-64

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Current build status
                   <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_64</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=win&configuration=win%20win_64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,4 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/recipe/build-libtiledbvcf.bat
+++ b/recipe/build-libtiledbvcf.bat
@@ -1,0 +1,21 @@
+@echo on
+
+mkdir libtiledbvcf-build
+cd libtiledbvcf-build
+
+rem configure
+cmake ^
+  -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+  -DOVERRIDE_INSTALL_PREFIX=OFF ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DFORCE_EXTERNAL_HTSLIB=OFF ^
+  ../libtiledbvcf
+if %ERRORLEVEL% neq 0 exit 1
+
+rem build
+cmake --build . --config Release --parallel %CPU_COUNT%
+if %ERRORLEVEL% neq 0 exit 1
+
+rem install
+cmake --build . --target install-libtiledbvcf --config Release
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,36 +49,38 @@ outputs:
         - tiledbvcf create --uri %SRC_DIR%\test-tiledbvcf-conda  # [win]
         - bash test-cli.sh  # [not win]
 
-  - name: tiledbvcf-py  # [not win]
-    version: {{ version }}  # [not win]
-    script: build-tiledbvcf-py.sh  # [not win]
-    requirements:  # [not win]
-      build:  # [not win]
-        - {{ compiler('cxx') }}  # [not win]
-      host:  # [not win]
-        - numpy  # [not win]
-        - libtiledbvcf {{ version }}  # [not win]
-        - python  # [not win]
-        - pyarrow 9.0.*  # [not win]
-        - pybind11 >=2.5  # [not win]
-        - wheel >=0.30  # [not win]
-        - setuptools >=18.0  # [not win]
-        - setuptools_scm 6.0.1  # [not win]
-        - setuptools_scm_git_archive  # [not win]
-      run:  # [not win]
-        - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}  # [not win]
-        - {{ pin_subpackage('libtiledbvcf', exact=True) }}  # [not win]
-        - python  # [not win]
-        - pyarrow 9.0.*  # [not win]
-        - pandas  # [not win]
-    imports:  # [not win]
-      - tiledbvcf  # [not win]
-    test:  # [not win]
-      files:  # [not win]
-        - test-api.py  # [not win]
-      commands:  # [not win]
-        - python -c "import tiledbvcf; tiledbvcf.version"  # [not win]
-        - python test-api.py  # [not win]
+{% if not win %}
+  - name: tiledbvcf-py
+    version: {{ version }}
+    script: build-tiledbvcf-py.sh
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+      host:
+        - numpy
+        - libtiledbvcf {{ version }}
+        - python
+        - pyarrow 9.0.*
+        - pybind11 >=2.5
+        - wheel >=0.30
+        - setuptools >=18.0
+        - setuptools_scm 6.0.1
+        - setuptools_scm_git_archive
+      run:
+        - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
+        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
+        - python
+        - pyarrow 9.0.*
+        - pandas
+    imports:
+      - tiledbvcf
+    test:
+      files:
+        - test-api.py
+      commands:
+        - python -c "import tiledbvcf; tiledbvcf.version"
+        - python test-api.py
+{% endif %}
 
 about:
   home: http://tiledb.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,28 +12,31 @@ source:
 
 build:
   number: 0
-  skip: true  # [win or linux32 or py2k]
+  skip: true  # [linux32 or py2k]
 
 outputs:
   - name: libtiledbvcf
     version: {{ version }}
-    script: build-libtiledbvcf.sh
+    script: build-libtiledbvcf.sh  # [not win]
+    script: build-libtiledbvcf.bat  # [win]
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - git
         - cmake
-        - make
+        - make  # [not win]
       host:
+        - htslib >=1.15  # [not win]
+        - m2w64-htslib >=1.15  # [win]
         - tiledb 2.15.*
-        - htslib >=1.15
       run:
+        - htslib >=1.15  # [not win]
+        - m2w64-htslib >=1.15  # [win]
         - tiledb 2.15.*
-        - htslib >=1.15
     test:
-      files:
-        - test-cli.sh
+      files:  # [not win]
+        - test-cli.sh  # [not win]
       commands:
         - tiledbvcf version
         # verify libhts is linked
@@ -42,39 +45,40 @@ outputs:
         # verify libdeflate is linked to libhts
         - ldd ${PREFIX}/lib/libhts.so.* | grep libdeflate  # [linux]
         - otool -L ${PREFIX}/lib/libhts.*.dylib | grep libdeflate  # [osx]
-        - tiledbvcf create --uri /tmp/test-tiledbvcf-conda
-        - bash test-cli.sh
+        - tiledbvcf create --uri /tmp/test-tiledbvcf-conda  # [not win]
+        - tiledbvcf create --uri %SRC_DIR%\test-tiledbvcf-conda  # [win]
+        - bash test-cli.sh  # [not win]
 
-  - name: tiledbvcf-py
-    version: {{ version }}
-    script: build-tiledbvcf-py.sh
-    requirements:
-      build:
-        - {{ compiler('cxx') }}
-      host:
-        - numpy
-        - libtiledbvcf {{ version }}
-        - python
-        - pyarrow 9.0.*
-        - pybind11 >=2.5
-        - wheel >=0.30
-        - setuptools >=18.0
-        - setuptools_scm 6.0.1
-        - setuptools_scm_git_archive
-      run:
-        - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
-        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
-        - python
-        - pyarrow 9.0.*
-        - pandas
-    imports:
-      - tiledbvcf
-    test:
-      files:
-        - test-api.py
-      commands:
-        - python -c "import tiledbvcf; tiledbvcf.version"
-        - python test-api.py
+  - name: tiledbvcf-py  # [not win]
+    version: {{ version }}  # [not win]
+    script: build-tiledbvcf-py.sh  # [not win]
+    requirements:  # [not win]
+      build:  # [not win]
+        - {{ compiler('cxx') }}  # [not win]
+      host:  # [not win]
+        - numpy  # [not win]
+        - libtiledbvcf {{ version }}  # [not win]
+        - python  # [not win]
+        - pyarrow 9.0.*  # [not win]
+        - pybind11 >=2.5  # [not win]
+        - wheel >=0.30  # [not win]
+        - setuptools >=18.0  # [not win]
+        - setuptools_scm 6.0.1  # [not win]
+        - setuptools_scm_git_archive  # [not win]
+      run:  # [not win]
+        - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}  # [not win]
+        - {{ pin_subpackage('libtiledbvcf', exact=True) }}  # [not win]
+        - python  # [not win]
+        - pyarrow 9.0.*  # [not win]
+        - pandas  # [not win]
+    imports:  # [not win]
+      - tiledbvcf  # [not win]
+    test:  # [not win]
+      files:  # [not win]
+        - test-api.py  # [not win]
+      commands:  # [not win]
+        - python -c "import tiledbvcf; tiledbvcf.version"  # [not win]
+        - python test-api.py  # [not win]
 
 about:
   home: http://tiledb.com


### PR DESCRIPTION
@dhoke4tdb's PRs to support Windows builds (https://github.com/TileDB-Inc/TileDB-VCF/pull/484, https://github.com/TileDB-Inc/TileDB-VCF/pull/506) were included in the recently released [0.23.0](https://github.com/TileDB-Inc/TileDB-VCF/releases/tag/0.23.0) (and merged in #80). This PR builds libtiledbvcf for Windows using [`tiledb::m2w64-htslib`](https://github.com/TileDB-Inc/m2w64-htslib-feedstock)

Notes:

* I didn't bump the build number since we don't need new builds for linux and macOS. But I did edit the recipe, so I'm open to bumping the build number if anyone feels strongly about it
* The build of tiledbvcf-py is purposefully skipped on Windows. I've documented the error, and started a draft at https://github.com/TileDB-Inc/TileDB-VCF/pull/507. I couldn't find a way to globally skip only tiledbvcf-py on Windows (please inform me if you know how), so I've added `# [not win]` to every line