### PR TITLE
Build tiledbvcf-py for Windows

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,14 +10,12 @@ numpy:
 - '1.21'
 - '1.20'
 - '1.20'
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.10.* *_cpython
-- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,5 +6,22 @@ channel_targets:
 - tiledb main
 cxx_compiler:
 - vs2019
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+- '1.20'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - win-64
+zip_keys:
+- - python
+  - numpy

--- a/recipe/build-tiledbvcf-py.bat
+++ b/recipe/build-tiledbvcf-py.bat
@@ -1,0 +1,6 @@
+@echo on
+
+cd apis\python
+
+%PYTHON% setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="%LIBRARY_PREFIX%"
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,17 +7,17 @@ channel_sources:
 channel_targets:
   - tiledb main
 numpy:
-  - 1.20   # [not (osx and arm64)]
+  - 1.20   # [not (osx and arm64) and not win]
   - 1.20
   - 1.20
   - 1.21
 python:
-  - 3.7.* *_cpython   # [not (osx and arm64)]
+  - 3.7.* *_cpython   # [not (osx and arm64) and not win]
   - 3.8.* *_cpython
   - 3.9.* *_cpython
   - 3.10.* *_cpython
 python_impl:
-  - cpython   # [not (osx and arm64)]
+  - cpython   # [not (osx and arm64) and not win]
   - cpython
   - cpython
   - cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,10 +49,10 @@ outputs:
         - tiledbvcf create --uri %SRC_DIR%\test-tiledbvcf-conda  # [win]
         - bash test-cli.sh  # [not win]
 
-{% if not win %}
   - name: tiledbvcf-py
     version: {{ version }}
-    script: build-tiledbvcf-py.sh
+    script: build-tiledbvcf-py.sh  # [not win]
+    script: build-tiledbvcf-py.bat  # [win]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -85,7 +85,6 @@ outputs:
       commands:
         - python -c "import tiledbvcf; tiledbvcf.version"
         - python test-api.py
-{% endif %}
 
 about:
   home: http://tiledb.com


### PR DESCRIPTION
The [0.24.0 release](https://github.com/TileDB-Inc/TileDB-VCF/releases/tag/0.24.0) included support for building tiledbvcf-py on Windows (https://github.com/TileDB-Inc/TileDB-VCF/pull/507)

xref: #81, #84 

Note I purposefully didn't bump the build number. We don't need new binaries uploaded for all the variants. We only need to upload tiledbvcf-py 0.24.0 for Windows

Update: the osx-arm64 builds failed in #84 yesterday, but were subsequently built and uploaded (post https://github.com/TileDB-Inc/htslib-feedstock/pull/7) by restarting the [Azure job](https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=32527&view=logs&j=d6e17299-69de-5342-9bfa-d2a6718dd363) from the [merge commit](https://github.com/TileDB-Inc/tiledb-vcf-feedstock/commit/6299145c4addd595d7280f59f4b6c46726772713)