### PR TITLE
Fix Azure links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
-            <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master">
+          <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=35&branchName=master">
+            <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledb-vcf-feedstock?branchName=master">
           </a>
         </summary>
         <table>
@@ -36,29 +36,29 @@ Current build status
           <tbody><tr>
               <td>linux_64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=35&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=35&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=35&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=master">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=win&configuration=win%20win_64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=35&branchName=master">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledb-vcf-feedstock?branchName=master&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,3 +11,7 @@ build_platform:
   osx_arm64: osx_64
 conda_forge_output_validation: true
 test_on_native_only: true
+azure:
+  build_id: 35
+  user_or_org: TileDB-Inc
+  project_name: CI


### PR DESCRIPTION
This PR fixes the links to the latest Azure builds in the README

The badges also render now, but unfortunately they don't show the current build status because conda smithy [hard codes](https://github.com/conda-forge/conda-smithy/blob/4e1e5a5b4aa5045a4851c643700ebb5057ec33b0/conda_smithy/templates/README.md.tmpl#L67) that the Azure pipeline should be named the same as the GitHub repo (ie tiledb-vcf-feedstock). Since the pipeline is named [TileDB VCF Feedstock CI](https://dev.azure.com/TileDB-Inc/CI/_build?definitionId=35), the badge only renders the status properly if this string is included in the url, eg [<img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/TileDB%20VCF%20Feedstock%20CI?branchName=master&jobName=linux&configuration=linux%20linux_64_">](https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/TileDB%20VCF%20Feedstock%20CI?branchName=master&jobName=linux&configuration=linux%20linux_64_)

Note: this is a feedstock documentation update only. No new conda binaries will be uploaded