### PR TITLE
Update sha256 for 0.25.0 tarball

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vcf" %}
 {% set version = "0.25.0" %}
-{% set sha256 = "1f559d190d8d6a83e33b00df5b273c5f32082b461b0f94a687030d8259b696a9" %}
+{% set sha256 = "0a8054b8d62bbbe7938d9ea3732749aa8abafca708308ccd8735fea5cb90da98" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
The sha256 checksum has changed since PR #89 was merged about 2 weeks ago

https://github.com/TileDB-Inc/tiledb-vcf-feedstock/blob/3937d44f2f8e8fa9d1060f4984b946c6989ae883/recipe/meta.yaml#L2-L3

```sh
curl -sL https://github.com/TileDB-Inc/TileDB-VCF/archive/0.25.0.tar.gz | openssl sha256
## SHA2-256(stdin)= 0a8054b8d62bbbe7938d9ea3732749aa8abafca708308ccd8735fea5cb90da98
```

We've discussed this before, and it's still unclear to me how often this should happen. The GitHub docs are ambiguous. For example, this [GitHub announcement from Jan 2023](https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/) states that GitHub archive tarballs are subject to change, but then this text was crossed out when the policy was reverted.

But assuming it is possible for the archive tarballs to change, I am confused why it seems to happen so regularly only for the TileDB-VCF repository. The [tiledbsoma recipe](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/d211e254236f1cbe1e11cebdb9edb3ad4b4842bb/recipe/meta.yaml#L17) also uses an archive tarball, it was also updated with a new version about 2 weeks ago (https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/35), and yet its checksum is stable:

```sh
curl -sL https://github.com/single-cell-data/TileDB-SOMA/archive/1.3.0.tar.gz | openssl sha256
## SHA2-256(stdin)= 1fb5bf86440a47b724ffb083143bda8a26d79e036336bac57ac7c1feaa5d4b9d
```

Also, the [example recipe](https://github.com/conda-forge/staged-recipes/blob/597a94367f6a10664fa7121d727c7eb8dc06bd24/recipes/example/meta.yaml#L21) in conda-forge/staged-recipes includes the option of using a GitHub archive tarball, and I know lots of recipes use this option. If the archive tarball checksum was really so unstable that it changed every few weeks, I would expect conda-forge to discourage its use since this would cause lots of build failures.

Do we have any clues to why this checksum issue is so specifically problematic for TileDB-VCF?