### PR TITLE
Support additional arrow build permutations

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,9 +20,15 @@ numpy:
 - '1.20'
 - '1.20'
 pin_run_as_build:
+  pyarrow:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+pyarrow:
+- '10.0'
+- '11.0'
+- '9.0'
 python:
 - 3.10.* *_cpython
 - 3.7.* *_cpython

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -27,7 +27,6 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
-- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -27,6 +27,7 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
+- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,9 +22,15 @@ numpy:
 - '1.20'
 - '1.20'
 pin_run_as_build:
+  pyarrow:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+pyarrow:
+- '10.0'
+- '11.0'
+- '9.0'
 python:
 - 3.10.* *_cpython
 - 3.7.* *_cpython

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -29,7 +29,6 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
-- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -29,6 +29,7 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
+- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -26,7 +26,6 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
-- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,9 +19,15 @@ numpy:
 - '1.20'
 - '1.20'
 pin_run_as_build:
+  pyarrow:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+pyarrow:
+- '10.0'
+- '11.0'
+- '9.0'
 python:
 - 3.10.* *_cpython
 - 3.8.* *_cpython

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -26,6 +26,7 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
+- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -18,7 +18,6 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
-- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -11,9 +11,15 @@ numpy:
 - '1.20'
 - '1.20'
 pin_run_as_build:
+  pyarrow:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
+pyarrow:
+- '10.0'
+- '11.0'
+- '9.0'
 python:
 - 3.10.* *_cpython
 - 3.8.* *_cpython

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -18,6 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 pyarrow:
 - '10.0'
+- '11.0'
 - '9.0'
 python:
 - 3.10.* *_cpython

--- a/recipe/0001-Update-python-pybind11-to-use-c-17.patch
+++ b/recipe/0001-Update-python-pybind11-to-use-c-17.patch
@@ -1,0 +1,33 @@
+From 8ab3191d553a7f1677f4f53576326459a71dfaee Mon Sep 17 00:00:00 2001
+From: Seth Shelnutt <Shelnutt2@gmail.com>
+Date: Thu, 27 Jul 2023 13:33:57 -0400
+Subject: [PATCH] Update python pybind11 to use c++17
+
+---
+ apis/python/setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/apis/python/setup.py b/apis/python/setup.py
+index 65d82456..5b5088b3 100644
+--- a/apis/python/setup.py
++++ b/apis/python/setup.py
+@@ -224,14 +224,14 @@ class BuildExtCmd(build_ext):
+ 
+     def build_extensions(self):
+         if sys.platform != "win32":
+-            opts = ["-std=c++11", "-g"]
++            opts = ["-std=c++17", "-g"]
+             if TILEDBVCF_DEBUG_BUILD:
+                 opts.extend(["-O0"])
+             else:
+                 opts.extend(["-O2"])
+         else:  # windows
+             # Note: newer versions of msvc cl may not recognize -std:c++11
+-            opts = ["-std:c++11", "-Zi"]
++            opts = ["-std:c++17", "-Zi"]
+             if TILEDBVCF_DEBUG_BUILD:
+                 opts.extend(["-Od"])
+             else:
+-- 
+2.40.0
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -21,3 +21,10 @@ python_impl:
   - cpython
   - cpython
   - cpython
+pyarrow:
+  - 9.0
+  - 10.0  # [py>=3.8]
+  - 11.0  # [py>=3.8]
+pin_run_as_build:
+  pyarrow:
+    max_pin: x.x

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -24,7 +24,7 @@ python_impl:
 pyarrow:
   - 9.0
   - 10.0
-  #- 11.0
+  - 11.0
 pin_run_as_build:
   pyarrow:
     max_pin: x.x

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -23,8 +23,8 @@ python_impl:
   - cpython
 pyarrow:
   - 9.0
-  - 10.0  # [py>=3.8]
-  - 11.0  # [py>=3.8]
+  - 10.0
+  - 11.0
 pin_run_as_build:
   pyarrow:
     max_pin: x.x

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -24,7 +24,7 @@ python_impl:
 pyarrow:
   - 9.0
   - 10.0
-  - 11.0
+  #- 11.0
 pin_run_as_build:
   pyarrow:
     max_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb-vcf" %}
 {% set version = "0.25.0" %}
-{% set sha256 = "1f559d190d8d6a83e33b00df5b273c5f32082b461b0f94a687030d8259b696a9" %}
+{% set sha256 = "0a8054b8d62bbbe7938d9ea3732749aa8abafca708308ccd8735fea5cb90da98" %}
 
 package:
   name: {{ name }}
@@ -59,7 +59,8 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
-        - pyarrow      
+        - pyarrow 9.0  # [py<=37]
+        - pyarrow {{ pyarrow }}  # [py>=38]
         - numpy                                  # [build_platform != target_platform]
       host:
         - numpy
@@ -76,7 +77,8 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow
+        - pyarrow 9.0  # [py<=37]
+        - pyarrow {{ pyarrow }}  # [py>=38]
         - pandas
     imports:
       - tiledbvcf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ package:
 source:
   url: https://github.com/TileDB-Inc/TileDB-VCF/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - 0001-Update-python-pybind11-to-use-c-17.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,13 +59,13 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
-        - pyarrow 9.0.*                          # [build_platform != target_platform]
+        - pyarrow      
         - numpy                                  # [build_platform != target_platform]
       host:
         - numpy
         - libtiledbvcf {{ version }}
         - python
-        - pyarrow 9.0.*
+        - pyarrow
         - pybind11 >=2.5
         - wheel >=0.30
         - setuptools >=18.0
@@ -75,7 +75,7 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - pyarrow 9.0.*
+        - pyarrow
         - pandas
     imports:
       - tiledbvcf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,8 @@ outputs:
         - numpy
         - libtiledbvcf {{ version }}
         - python
-        - pyarrow
+        - pyarrow 9.0  # [py<=37]
+        - pyarrow {{ pyarrow }}  # [py>=38]
         - pybind11 >=2.5
         - wheel >=0.30
         - setuptools >=18.0


### PR DESCRIPTION
This adds support for pyarrow 10 and 11 for python 3.8 and newer. This helps users install TileDB-VCF in various environments.

Special thanks to @jdblischak for figuring out the permutation method!