### PR TITLE
[backport] Build TileDB-VCF 0.26 + TileDB 2.17 with new htslib versions

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,7 +20,6 @@ numpy:
 - '1.21'
 - '1.21'
 - '1.21'
-- '1.21'
 pin_run_as_build:
   pyarrow:
     min_pin: x.x.x
@@ -34,7 +33,6 @@ pyarrow:
 - 9.0.0
 python:
 - 3.10.* *_cpython
-- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,17 +7,17 @@ channel_sources:
 channel_targets:
   - tiledb main
 numpy:
-  - 1.21   # [not (osx and arm64) and not win]
+  - 1.21    # [linux]
   - 1.21
   - 1.21
   - 1.21
 python:
-  - 3.7.* *_cpython   # [not (osx and arm64) and not win]
+  - 3.7.* *_cpython   # [linux]
   - 3.8.* *_cpython
   - 3.9.* *_cpython
   - 3.10.* *_cpython
 python_impl:
-  - cpython   # [not (osx and arm64) and not win]
+  - cpython    # [linux]
   - cpython
   - cpython
   - cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [linux32 or py2k]
 
 outputs:


### PR DESCRIPTION
@awenocur please review. I can self-merge after you approve

Closes #106

## Background

I have recently built newer versions of htslib and m2w64-htslib and uploaded them to the tiledb channel. The next step is to rebuild the TileDB-VCF conda binaries to link against these newer versions. This is critical for being able to install TileDB-VCF in the same conda environment as more recent versions of samtools, bcftools, etc

The recent PR #105 that bumped TileDB to 2.18 was only able to successfully build a linux-64 binary. Thus currently only TileDB-VCF 0.27.1 + TileDB 2.18 has been built against htslib 1.19. By rebuilding the previous version of TileDB-VCF on a branch, the binaries for all platforms will be built against a newer htslib

## Notes

* This PR is merging into Adam's most recent backport branch, sc-38358, which built and uploaded 0.26.7. This branch doesn't include my recent update to limit uploads to the master branch (#104), so it will automatically upload the binaries to the tiledb channel
* I dropped the py37 build for osx-64. It wasn't immediately clear to me why the py37 osx-64 env wouldn't build while the linux-64 one did. However, I decided it wasn't worth troubleshooting because we only maintain a py37 environment on linux-64 in the rest of the TileDB ecosystem (eg we have only been building the upstream TileDB-Py for py37 on linux-64 for months now). As per our discussion on Slack, I dropped the py37 osx-64 build

