### PR TITLE
Drop osx-64 py37 build to reveal AWS error

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,7 +18,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.22'
-- '1.21'
 - '1.22'
 - '1.22'
 pin_run_as_build:
@@ -32,7 +31,6 @@ pyarrow:
 - 11.*
 python:
 - 3.10.* *_cpython
-- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,17 +7,17 @@ channel_sources:
 channel_targets:
   - tiledb main
 numpy:
-  - 1.21   # [not (osx and arm64) and not win]
+  - 1.21   # [linux]
   - 1.22
   - 1.22
   - 1.22
 python:
-  - 3.7.* *_cpython   # [not (osx and arm64) and not win]
+  - 3.7.* *_cpython   # [linux]
   - 3.8.* *_cpython
   - 3.9.* *_cpython
   - 3.10.* *_cpython
 python_impl:
-  - cpython   # [not (osx and arm64) and not win]
+  - cpython   # [linux]
   - cpython
   - cpython
   - cpython


### PR DESCRIPTION
The osx-64 build was failing during the recent PR to migrate to TileDB 2.18 (#105) due to an AWS error. However, the final osx-64 build failure prior to merging that PR was actually a conda solver error. This is because I uploaded htslib 1.19 (#106), which installed fine into a linux-64 py37 env but *not* into an osx-64 py37 env. Similar to the approach in #107, this PR drops the unnecessary osx-64 py37 build.

This obviously won't get us an osx-64 build, but it at least reveals the AWS error we actually need to troubleshoot, which is:


```sh
+ python test-api.py
Fatal error condition occurred in /Users/runner/miniforge3/conda-bld/aws-c-common_1701169789367/work/source/allocator.c:172: allocator != ((void*)0)
Exiting Application
################################################################################
Stack trace:
################################################################################
1   libaws-c-common.1.0.0.dylib         0x00000001088c60e4 aws_fatal_assert + 68
2   libaws-c-common.1.0.0.dylib         0x00000001088c3497 aws_mem_acquire + 55
3   libaws-c-common.1.0.0.dylib         0x00000001088de6c2 aws_string_new_from_cursor + 50
4   libaws-c-common.1.0.0.dylib         0x00000001088d4f46 aws_json_value_get_from_object + 54
5   libaws-c-sdkutils.1.0.0.dylib       0x0000000108a592de aws_endpoints_ruleset_new_from_string + 110
6   libaws-crt-cpp.dylib                0x00000001088092dd _ZN3Aws3Crt9Endpoints10RuleEngineC2ERK15aws_byte_cursorS5_P13aws_allocator + 45
7   libaws-cpp-sdk-s3.dylib             0x00000001078d0543 _ZN3Aws8Endpoint23DefaultEndpointProviderINS_2S321S3ClientConfigurationENS2_8Endpoint19S3BuiltInParametersENS4_25S3ClientContextParametersEEC2EPKcm + 147
8   libtiledb.dylib                     0x000000012f92be60 _ZN3Aws2S38S3ClientC2ERKNS_6Client19ClientConfigurationENS2_15AWSAuthV4Signer20PayloadSigningPolicyEbNS0_34US_EAST_1_REGIONAL_ENDPOINT_OPTIONE + 720
9   libtiledb.dylib                     0x000000012ef86a82 _ZN6tiledb6common11make_sharedINS_2sm14TileDBS3ClientELi93EJRKNS2_12S3ParametersERN3Aws6Client19ClientConfigurationENS8_15AWSAuthV4Signer20PayloadSigningPolicyERKbEEENSt3__110shared_ptrIT_EERAT0__KcDpOT1_ + 98
10  libtiledb.dylib                     0x000000012ef6c9fe _ZNK6tiledb2sm2S311init_clientEv + 3678
11  libtiledb.dylib                     0x000000012ef7672d _ZNK6tiledb2sm2S313ls_with_sizesERKNS0_3URIERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEEi + 61
12  libtiledb.dylib                     0x000000012efa52e9 _ZNK6tiledb2sm3VFS13ls_with_sizesERKNS0_3URIE + 345
13  libtiledb.dylib                     0x000000012efa8ed2 _ZNK6tiledb2sm3VFS2lsERKNS0_3URIEPNSt3__16vectorIS2_NS5_9allocatorIS2_EEEE + 114
14  libtiledb.dylib                     0x000000012f04904a _ZN6tiledb2sm14GroupDirectory22load_group_detail_urisEv + 106
15  libtiledb.dylib                     0x000000012f049902 _ZNSt3__120__packaged_task_funcIZN6tiledb6common10ThreadPool5asyncIZNS1_2sm14GroupDirectory4loadEvE3$_2JEEEDaOT_DpOT0_EUlvE_NS_9allocatorISD_EEFNS2_6StatusEvEEclEv + 18
16  libtiledb.dylib                     0x000000012f82e116 _ZNSt3__113packaged_taskIFN6tiledb6common6StatusEvEEclEv + 102
17  libtiledb.dylib                     0x000000012f82e71e _ZN6tiledb6common10ThreadPool15wait_all_statusERNSt3__16vectorINS2_6futureINS0_6StatusEEENS2_9allocatorIS6_EEEE + 622
18  libtiledb.dylib                     0x000000012f82e3f7 _ZN6tiledb6common10ThreadPool8wait_allERNSt3__16vectorINS2_6futureINS0_6StatusEEENS2_9allocatorIS6_EEEE + 39
19  libtiledb.dylib                     0x000000012f04674e _ZN6tiledb2sm14GroupDirectory4loadEv + 1582
20  libtiledb.dylib                     0x000000012f045f93 _ZN6tiledb2sm14GroupDirectoryC2EPNS0_3VFSEPNS_6common10ThreadPoolERKNS0_3URIEyyNS0_18GroupDirectoryModeE + 179
21  libtiledb.dylib                     0x000000012f046ead _ZN6tiledb2sm14GroupDirectoryC1EPNS0_3VFSEPNS_6common10ThreadPoolERKNS0_3URIEyyNS0_18GroupDirectoryModeE + 13
22  libtiledb.dylib                     0x000000012f03adb7 _ZN6tiledb6common11make_sharedINS_2sm14GroupDirectoryELi90EJPNS2_3VFSEPNS0_10ThreadPoolERNS2_3URIERySA_EEENSt3__110shared_ptrIT_EERAT0__KcDpOT1_ + 119
23  libtiledb.dylib                     0x000000012f03a89d _ZN6tiledb2sm5Group4openENS0_9QueryTypeEyy + 1789
24  libtiledb.dylib                     0x000000012f03b114 _ZN6tiledb2sm5Group4openENS0_9QueryTypeE + 276
25  libtiledb.dylib                     0x000000012f8528d6 _ZN6tiledb3api17tiledb_group_openEP21tiledb_group_handle_t19tiledb_query_type_t + 54
26  libtiledb.dylib                     0x000000012f856a92 _ZN6tiledb3api12CAPIFunctionIXadL_ZNS0_17tiledb_group_openEP21tiledb_group_handle_t19tiledb_query_type_tEENS0_6detail24ExceptionActionDetailCtxENS0_22CAPIFunctionNullAspectIXadL_ZNS0_17tiledb_group_openES3_S4_EEEEE8functionERS6_S3_S4_ + 66
27  libtiledb.dylib                     0x000000012f8555c5 tiledb_group_open + 53
28  libtiledbvcf.dylib                  0x000000012eafb7dc _ZN6tiledb5GroupC2ERKNS_7ContextERKNSt3__112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE19tiledb_query_type_tP22tiledb_config_handle_t + 412
29  libtiledbvcf.dylib                  0x000000012eaed4a4 _ZN6tiledb3vcf16TileDBVCFDataset10open_arrayE19tiledb_query_type_tRKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEESB_SB_ + 180
30  libtiledbvcf.dylib                  0x000000012eae343b _ZN6tiledb3vcf16TileDBVCFDataset15open_data_arrayE19tiledb_query_type_t + 171
31  libtiledbvcf.dylib                  0x000000012eae1ce2 _ZN6tiledb3vcf16TileDBVCFDataset4openERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKNS2_6vectorIS8_NS6_IS8_EEEEb + 450
32  libtiledbvcf.dylib                  0x000000012eb31898 _ZN6tiledb3vcf6Reader12open_datasetERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 200
33  libtiledbvcf.dylib                  0x000000012eac0c65 tiledb_vcf_reader_init + 357
34  libtiledbvcf.cpython-310-darwin.so  0x0000000134ee519f _ZN11tiledbvcfpy6Reader4initERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 31
35  libtiledbvcf.cpython-310-darwin.so  0x0000000134edf59c _ZZN8pybind1112cpp_function10initializeIZNS0_C1IvN11tiledbvcfpy6ReaderEJRKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEEEJNS_4nameENS_9is_methodENS_7siblingEEEEMT0_FT_DpT1_EDpRKT2_EUlPS4_SD_E_vJSR_SD_EJSE_SF_SG_EEEvOSI_PFSH_SK_ESQ_ENKUlRNS_6detail13function_callEE_clESY_ + 188
36  libtiledbvcf.cpython-310-darwin.so  0x0000000134edf4c2 _ZZN8pybind1112cpp_function10initializeIZNS0_C1IvN11tiledbvcfpy6ReaderEJRKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEEEJNS_4nameENS_9is_methodENS_7siblingEEEEMT0_FT_DpT1_EDpRKT2_EUlPS4_SD_E_vJSR_SD_EJSE_SF_SG_EEEvOSI_PFSH_SK_ESQ_ENUlRNS_6detail13function_callEE_8__invokeESY_ + 34
37  libtiledbvcf.cpython-310-darwin.so  0x0000000134ed0daa _ZN8pybind1112cpp_function10dispatcherEP7_objectS2_S2_ + 4746
38  python                              0x0000000103d34048 cfunction_call + 56
39  python                              0x0000000103cd4188 _PyObject_MakeTpCall + 312
40  python                              0x0000000103cda8b2 method_vectorcall + 690
41  python                              0x0000000103df6b80 _PyEval_EvalFrameDefault + 46176
42  python                              0x0000000103cd5870 _PyFunction_Vectorcall + 560
43  python                              0x0000000103d64e2c slot_tp_init + 556
44  python                              0x0000000103d5962b type_call + 267
45  python                              0x0000000103e18fe3 call_function + 611
46  python                              0x0000000103df43a2 _PyEval_EvalFrameDefault + 35970
47  python                              0x0000000103de98e0 _PyEval_Vector + 544
48  python                              0x0000000103e6e530 run_mod + 240
49  python                              0x0000000103e6e2f5 pyrun_file + 133
50  python                              0x0000000103e6ddff _PyRun_SimpleFileObject + 319
51  python                              0x0000000103e6d77f _PyRun_AnyFileObject + 143
52  python                              0x0000000103e92e48 pymain_run_file_obj + 216
53  python                              0x0000000103e928d5 pymain_run_file + 85
54  python                              0x0000000103e92018 pymain_run_python + 376
55  python                              0x0000000103e91e55 Py_RunMain + 37
56  python                              0x0000000103c71708 main + 56
57  libdyld.dylib                       0x00007fff20565f3d start + 1
/Users/runner/miniforge3/conda-bld/tiledb-vcf_1704815113157/test_tmp/run_test.sh: line 8: 10952 Abort trap: 6           python test-api.py
WARNING: Tests failed for tiledbvcf-py-0.27.1-py310h56ba9c6_1.conda - moving package to /Users/runner/miniforge3/conda-bld/broken
TESTS FAILED: tiledbvcf-py-0.27.1-py310h56ba9c6_1.conda
```
