### PR TITLE
Loosen pyarrow pin

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,14 +20,9 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  pyarrow:
-    min_pin: x
-    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x
-pyarrow:
-- 11.*
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,14 +22,9 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  pyarrow:
-    min_pin: x
-    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x
-pyarrow:
-- 11.*
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -20,14 +20,9 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  pyarrow:
-    min_pin: x
-    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x
-pyarrow:
-- 11.*
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,14 +12,9 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  pyarrow:
-    min_pin: x
-    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x
-pyarrow:
-- 11.*
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,9 +6,3 @@ channel_sources:
   - conda-forge,tiledb
 channel_targets:
   - tiledb main
-pyarrow:
-  - 11.*
-pin_run_as_build:
-  pyarrow:
-    min_pin: x
-    max_pin: x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [linux32 or py2k]
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,15 +59,13 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
-        - pyarrow 9.*                          # [py<=37 and build_platform != target_platform]
-        - pyarrow {{ pyarrow }}                  # [py>=38 and build_platform != target_platform]
+        - pyarrow                                # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
       host:
         - numpy
         - libtiledbvcf {{ version }}
         - python
-        - pyarrow 9.*  # [py<=37]
-        - pyarrow  {{ pyarrow }}  # [py>=38]
+        - pyarrow >=14.0.2
         - pybind11 >=2.5
         - wheel >=0.30
         - setuptools >=18.0
@@ -77,7 +75,7 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
-        - {{ pin_compatible('pyarrow', max_pin='x') }}
+        - pyarrow >=14.0.2
         - pandas
     imports:
       - tiledbvcf
@@ -104,5 +102,3 @@ extra:
     - ihnorton
     - shelnutt2
     - jdblischak
-
-# touch to re-force CI (re-run button not working, IDK why)


### PR DESCRIPTION
Background:

* Currently getting aws-sdk-solver errors in https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/111, likely due to pyarrow 11 no longer being built against the latest conda-forge pins
* TileDB-VCF was migrated to use the arrow C data interface in https://github.com/TileDB-Inc/TileDB-VCF/pull/653
* tiledb-feedstock now installs aws-sdk-cpp from conda-forge (https://github.com/conda-forge/tiledb-feedstock/pull/241)
* We recently dropped the py37 builds in https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/112