### PR TITLE
Update to 0.32, which uses scikit-build-core

### DIFF
--- a/recipe/build-tiledbvcf-py.bat
+++ b/recipe/build-tiledbvcf-py.bat
@@ -1,9 +1,5 @@
 @echo on
 
-cd apis\python
-
-%PYTHON% setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="%LIBRARY_PREFIX%"
-if %ERRORLEVEL% neq 0 exit 1
-
-%PYTHON% setup.py clean --all
+set "LIBTILEDBVCF_PATH=%LIBRARY_LIB%"
+%PYTHON% -m pip install --no-deps --no-build-isolation -v apis\python
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/build-tiledbvcf-py.sh
+++ b/recipe/build-tiledbvcf-py.sh
@@ -2,8 +2,5 @@
 
 set -ex
 
-cd apis/python
-
-$PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="${PREFIX}"
-
-$PYTHON setup.py clean --all
+export LIBTILEDBVCF_PATH=$PREFIX/lib/
+$PYTHON -m pip install --no-deps --no-build-isolation -v apis/python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,16 @@
 {% set name = "tiledb-vcf" %}
-{% set version = "0.31.1" %}
-{% set sha256 = "86fc17a375025ee89472efbe59ef048d2485ca8d8702bd2b065c35b5852b8a09" %}
+{% set version = "0.32.0rc1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/TileDB-Inc/TileDB-VCF/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  # Have to use Git tag as source so that setuptools-scm
+  # can auto-configure the version number
+  git_url: https://github.com/TileDB-Inc/TileDB-VCF.git
+  git_rev: {{ version }}
+  git_depth: -1
 
 build:
   number: 0
@@ -23,6 +25,7 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ stdlib("c") }}
         - git
         - cmake
         - make  # [not win]
@@ -55,6 +58,9 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
+        - {{ stdlib("c") }}
+        - cmake
+        - make  # [not win]
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pyarrow                                # [build_platform != target_platform]
@@ -70,8 +76,10 @@ outputs:
         - pybind11 >=2.5
         - wheel >=0.30
         - setuptools >=18.0
-        - setuptools_scm 6.0.1
+        - setuptools_scm >=6.0.1
         - setuptools_scm_git_archive
+        - pip
+        - scikit-build-core
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}


### PR DESCRIPTION
This PR updates the conda recipe to use the new scikit-build-core setup introduced in https://github.com/TileDB-Inc/TileDB-VCF/pull/701

The previous workaround to enable setuptools-scm to work with a GitHub release tarball (https://github.com/TileDB-Inc/TileDB-VCF/pull/85) no longer works with scikit-build-core. Thus we are switching to using Git tags as the recipe source.

Once we have released/tagged 0.32.0, we just have to update the version string in `recipe/meta.yaml`