### PR TITLE
Build with libcxx 18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   git_depth: -1
 
 build:
-  number: 1
+  number: 2
   skip: true  # [linux32 or py2k]
 
 outputs:
@@ -29,19 +29,13 @@ outputs:
         - git
         - cmake
         - make  # [not win]
-        # Helps resolve Illegal instruction in tests
-        - libcxx <18          # [osx and x86_64]
       host:
         - htslib >=1.15  # [not win]
         - m2w64-htslib >=1.15  # [win]
         - tiledb 2.25.*
-        # Helps resolve Illegal instruction in tests
-        - libcxx <18          # [osx and x86_64]
       run:
         - htslib >=1.15  # [not win]
         - m2w64-htslib >=1.15  # [win]
-        # Helps resolve Illegal instruction in tests
-        - libcxx <18     # [osx and x86_64]
     test:
       files:  # [not win]
         - test-cli.sh  # [not win]
@@ -73,8 +67,6 @@ outputs:
         - pyarrow-hotfix                         # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
-        # Helps resolve Illegal instruction in tests
-        - libcxx <18          # [osx and x86_64]
       host:
         - numpy
         - libtiledbvcf {{ version }}
@@ -88,8 +80,6 @@ outputs:
         - setuptools_scm_git_archive
         - pip
         - scikit-build-core
-        # Helps resolve Illegal instruction in tests
-        - libcxx <18          # [osx and x86_64]
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.27') }}
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
@@ -97,8 +87,6 @@ outputs:
         - pyarrow
         - pyarrow-hotfix
         - pandas
-        # Helps resolve Illegal instruction in tests
-        - libcxx <18     # [osx and x86_64]
     imports:
       - tiledbvcf
     test:


### PR DESCRIPTION
The issue with libcxx 18 from conda-forge has been resolved. They had enabled a new hardening mode in libcxx 18 that searches for undefined behavior (https://github.com/conda-forge/libcxx-feedstock/issues/162#issuecomment-2259284699). Disabling this hardening removes the `Illegal instruction` error (https://github.com/conda-forge/libcxx-feedstock/pull/173, https://github.com/conda-forge/libcxx-feedstock/pull/174).

xref: #125, #131
