### PR TITLE
Build with clang 17

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -34,6 +34,8 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - linux-64
+tiledb:
+- '2.26'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -36,6 +36,8 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - osx-64
+tiledb:
+- '2.26'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -36,6 +36,8 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - osx-arm64
+tiledb:
+- '2.26'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -24,6 +24,10 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - win-64
+tiledb:
+- '2.26'
+vc:
+- '14'
 zip_keys:
 - - python
   - numpy

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,6 +7,6 @@ channel_sources:
 channel_targets:
   - tiledb main
 c_compiler_version:  # [osx]
-- '16'  # [osx]
+- '17'  # [osx]
 cxx_compiler_version:  # [osx]
-- '16'  # [osx]
+- '17'  # [osx]


### PR DESCRIPTION
We observed yesterday that the libtiledbvcf compilation failed when using clang 18 for the osx-64 and osx-arm64 builds (https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/141#issuecomment-2450229359). We fixed it by pinning to clang 16, which was known to work. This tests against clang 17.

An aside: note that the tiledb pins were added back to the `.ci_support/` files when I rerendered because I have conda-build 24.9 installed locally (whereas previously I had 24.5.1 installed; xref: https://github.com/conda-forge/r-tiledb-feedstock/pull/91#discussion_r1826135225)

