### PR TITLE
Update TileDB-VCF to 0.38.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tiledb-vcf" %}
-{% set version = "0.38.0" %}
+{% set version = "0.38.2" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Note that this PR omits a smithy rerender to avoid a compiler error during CI, per PR #149.