### PR TITLE
Updates TileDB-VCF to 0.40.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tiledb-vcf" %}
-{% set version = "0.40.1" %}
+{% set version = "0.40.2" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
* Updates TileDB-VCF to 0.40.2; see [release](https://github.com/TileDB-Inc/TileDB-VCF/releases/tag/0.40.2) for details